### PR TITLE
Alter interface to reduce confusion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub trait ColumnarRegion<T> : Default {
     /// Add a new element to the region.
     ///
     /// The argument will be copied in to the region and returned as an
-    /// owned instance. It is unsafe to drop the result.
+    /// owned instance. It is unsafe to unwrap and then drop the result.
     unsafe fn copy(&mut self, item: &T) -> ManuallyDrop<T>;
     /// Retain allocations but discard their contents.
     ///


### PR DESCRIPTION
This PR tweaks the `fn copy` interface to take an `item: &T` as an input and return a `T` as an output. The returned value should not be dropped (unsafe to do so). This is meant to make the interface a bit more clear, in that there are fewer `*mut T` things flopping around. 

There is the risk that it is "more unsafe" because it is easy to call `copy(item)` and just walk away; arguably the result should be wrapped in `ManuallyDrop` but the method is still unsafe and there is just a bit more screwing around with the result. There is also the risk that performance could now be worse, because we need to rely on Rust and LLVM to recover `memcpy` performance.

cc: @nico-abram