### PR TITLE
Convenience changes, tuple region macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+paste = "1.0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,6 @@
 //! keyword and Rust's safety is not yet clearly enough specified
 //! for me to make any stronger statements than that.
 
-use std::borrow::Borrow;
-
 /// A type that can absorb owned data from type `T`.
 ///
 /// This type will ensure that absorbed data remain valid as long as the
@@ -278,18 +276,18 @@ impl<T: Columnation> Default for ColumnStack<T> {
     }
 }
 
-impl<T: Columnation, B: Borrow<T>> Extend<B> for ColumnStack<T> {
-    fn extend<I: IntoIterator<Item=B>>(&mut self, iter: I) {
+impl<'a, T: Columnation + 'a> Extend<&'a T> for ColumnStack<T> {
+    fn extend<I: IntoIterator<Item=&'a T>>(&mut self, iter: I) {
         for element in iter {
-            self.copy(element.borrow())
+            self.copy(element)
         }
     }
 }
 
-impl<A: Columnation, B: Borrow<A>> std::iter::FromIterator<B> for ColumnStack<A> {
-    fn from_iter<T: IntoIterator<Item=B>>(iter: T) -> Self {
+impl<'a, T: Columnation + 'a> std::iter::FromIterator<&'a T> for ColumnStack<T> {
+    fn from_iter<I: IntoIterator<Item=&'a T>>(iter: I) -> Self {
         let iter = iter.into_iter();
-        let mut c = ColumnStack::<A>::with_capacity(iter.size_hint().0);
+        let mut c = ColumnStack::<T>::with_capacity(iter.size_hint().0);
         c.extend(iter);
         c
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,6 +340,7 @@ mod implementations {
     }
     implement_columnation!(());
     implement_columnation!(bool);
+    implement_columnation!(char);
 
     implement_columnation!(u8);
     implement_columnation!(u16);
@@ -354,6 +355,18 @@ mod implementations {
     implement_columnation!(i64);
     implement_columnation!(i128);
     implement_columnation!(isize);
+
+    implement_columnation!(f32);
+    implement_columnation!(f64);
+
+    implement_columnation!(std::num::Wrapping<i8>);
+    implement_columnation!(std::num::Wrapping<i16>);
+    implement_columnation!(std::num::Wrapping<i32>);
+    implement_columnation!(std::num::Wrapping<i64>);
+    implement_columnation!(std::num::Wrapping<i128>);
+    implement_columnation!(std::num::Wrapping<isize>);
+
+    implement_columnation!(std::time::Duration);
 
     /// Implementations for `Option<T: Columnation>`.
     pub mod option {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,81 +496,85 @@ mod implementations {
         }
     }
 
-    /// Implementation for tuples. Macros seemed hard.
+    /// Implementation for tuples.
     pub mod tuple {
 
         use super::{Columnation, Region};
 
-        impl<T0: Columnation, T1: Columnation> Columnation for (T0, T1) {
-            type InnerRegion = Tuple2Region<T0::InnerRegion, T1::InnerRegion>;
+        use paste::paste;
+
+        /// The macro creates
+        macro_rules! tuple_columnation {
+            ( $($name:ident)+) => ( paste! {
+                impl<$($name: Columnation),*> Columnation for ($($name,)*) {
+                    type InnerRegion = [<Tuple $($name)* Region >]<$($name::InnerRegion,)*>;
+                }
+
+                #[allow(non_snake_case)]
+                #[derive(Default)]
+                pub struct [<Tuple $($name)* Region >]<$($name: Region),*> {
+                    $([<region $name>]: $name),*
+                }
+
+                #[allow(non_snake_case)]
+                impl<$($name: Region),*> [<Tuple $($name)* Region>]<$($name),*> {
+                    #[allow(clippy::too_many_arguments)]
+                    #[inline] pub unsafe fn copy_destructured(&mut self, $([<r $name>]: &$name::Item),*) -> <[<Tuple $($name)* Region>]<$($name),*> as Region>::Item {
+                        (
+                            $(self.[<region $name>].copy(&[<r $name>]),)*
+                        )
+                    }
+                }
+
+                #[allow(non_snake_case)]
+                impl<$($name: Region),*> Region for [<Tuple $($name)* Region>]<$($name),*> {
+                    type Item = ($($name::Item,)*);
+                    #[inline]
+                    fn clear(&mut self) {
+                        $(self.[<region $name>].clear());*
+                    }
+                    #[inline] unsafe fn copy(&mut self, item: &Self::Item) -> Self::Item {
+                        let ($(ref $name,)*) = *item;
+                        (
+                            $(self.[<region $name>].copy($name),)*
+                        )
+                    }
+                }
+                }
+            );
         }
 
-        #[derive(Default)]
-        pub struct Tuple2Region<R0: Region, R1: Region> {
-            region0: R0,
-            region1: R1,
-        }
-
-        impl<R0: Region, R1: Region> Tuple2Region<R0, R1> {
-            #[inline] pub unsafe fn copy_destructured(&mut self, r0: &R0::Item, r1: &R1::Item) -> <Tuple2Region<R0, R1> as Region>::Item {
-                (
-                    self.region0.copy(&r0),
-                    self.region1.copy(&r1),
-                )
-            }
-        }
-
-        impl<R0: Region, R1: Region> Region for Tuple2Region<R0, R1> {
-            type Item = (R0::Item, R1::Item);
-            #[inline]
-            fn clear(&mut self) {
-                self.region0.clear();
-                self.region1.clear();
-            }
-            #[inline] unsafe fn copy(&mut self, item: &Self::Item) -> Self::Item {
-                (
-                    self.region0.copy(&item.0),
-                    self.region1.copy(&item.1),
-                )
-            }
-        }
-
-        impl<T0: Columnation, T1: Columnation, T2: Columnation> Columnation for (T0, T1, T2) {
-            type InnerRegion = Tuple3Region<T0::InnerRegion, T1::InnerRegion, T2::InnerRegion>;
-        }
-
-        #[derive(Default)]
-        pub struct Tuple3Region<R0: Region, R1: Region, R2: Region> {
-            region0: R0,
-            region1: R1,
-            region2: R2,
-        }
-
-        impl<R0: Region, R1: Region, R2: Region> Tuple3Region<R0, R1, R2> {
-            #[inline] pub unsafe fn copy_destructured(&mut self, r0: &R0::Item, r1: &R1::Item, r2: &R2::Item) -> <Tuple3Region<R0, R1, R2> as Region>::Item {
-                (
-                    self.region0.copy(r0),
-                    self.region1.copy(r1),
-                    self.region2.copy(r2),
-                )
-            }
-        }
-
-        impl<R0: Region, R1: Region, R2: Region> Region for Tuple3Region<R0, R1, R2> {
-            type Item = (R0::Item, R1::Item, R2::Item);
-            #[inline]
-            fn clear(&mut self) {
-                self.region0.clear();
-                self.region1.clear();
-                self.region2.clear();
-            }
-            #[inline] unsafe fn copy(&mut self, item: &Self::Item) -> Self::Item {
-                (
-                    self.region0.copy(&item.0),
-                    self.region1.copy(&item.1),
-                    self.region2.copy(&item.2),
-                )
-            }
-        }
+        tuple_columnation!(A);
+        tuple_columnation!(A B);
+        tuple_columnation!(A B C);
+        tuple_columnation!(A B C D);
+        tuple_columnation!(A B C D E);
+        tuple_columnation!(A B C D E F);
+        tuple_columnation!(A B C D E F G);
+        tuple_columnation!(A B C D E F G H);
+        tuple_columnation!(A B C D E F G H I);
+        tuple_columnation!(A B C D E F G H I J);
+        tuple_columnation!(A B C D E F G H I J K);
+        tuple_columnation!(A B C D E F G H I J K L);
+        tuple_columnation!(A B C D E F G H I J K L M);
+        tuple_columnation!(A B C D E F G H I J K L M N);
+        tuple_columnation!(A B C D E F G H I J K L M N O);
+        tuple_columnation!(A B C D E F G H I J K L M N O P);
+        tuple_columnation!(A B C D E F G H I J K L M N O P Q);
+        tuple_columnation!(A B C D E F G H I J K L M N O P Q R);
+        tuple_columnation!(A B C D E F G H I J K L M N O P Q R S);
+        tuple_columnation!(A B C D E F G H I J K L M N O P Q R S T);
+        tuple_columnation!(A B C D E F G H I J K L M N O P Q R S T U);
+        tuple_columnation!(A B C D E F G H I J K L M N O P Q R S T U V);
+        tuple_columnation!(A B C D E F G H I J K L M N O P Q R S T U V W);
+        tuple_columnation!(A B C D E F G H I J K L M N O P Q R S T U V W X);
+        tuple_columnation!(A B C D E F G H I J K L M N O P Q R S T U V W X Y);
+        tuple_columnation!(A B C D E F G H I J K L M N O P Q R S T U V W X Y Z);
+        tuple_columnation!(A B C D E F G H I J K L M N O P Q R S T U V W X Y Z AA);
+        tuple_columnation!(A B C D E F G H I J K L M N O P Q R S T U V W X Y Z AA AB);
+        tuple_columnation!(A B C D E F G H I J K L M N O P Q R S T U V W X Y Z AA AB AC);
+        tuple_columnation!(A B C D E F G H I J K L M N O P Q R S T U V W X Y Z AA AB AC AD);
+        tuple_columnation!(A B C D E F G H I J K L M N O P Q R S T U V W X Y Z AA AB AC AD AE);
+        tuple_columnation!(A B C D E F G H I J K L M N O P Q R S T U V W X Y Z AA AB AC AD AE AF);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,8 +178,9 @@ impl<T: Columnation> ColumnStack<T> {
     /// Construct a [ColumnStack], reserving space for `capacity` elements
     ///
     /// Note that the associated region is not initialized to a specific capacity
-    /// because we can't generally know how much space would be required.
-    pub fn with_capacity(capacity: usize) -> Self {
+    /// because we can't generally know how much space would be required. For this reason,
+    /// this function is private.
+    fn with_capacity(capacity: usize) -> Self {
         Self {
             local: Vec::with_capacity(capacity),
             inner: T::InnerRegion::default(),


### PR DESCRIPTION
This PR adds convenience implementations for `ColumnStack` and:
* Macro to generate the tuple regions
* More types
* destructured copy for tuples.