### PR TITLE
Add `with_capacity_for` method

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -23,6 +23,23 @@ use test::Bencher;
 #[bench] fn vec_u_s_clone(bencher: &mut Bencher) { _bench_clone(bencher, vec![vec![(0u64, format!("grawwwwrr!")); 32]; 32]); }
 #[bench] fn vec_u_vn_s_clone(bencher: &mut Bencher) { _bench_clone(bencher, vec![vec![(0u64, vec![(); 1 << 40], format!("grawwwwrr!")); 32]; 32]); }
 
+#[bench] fn empty_realloc(bencher: &mut Bencher) { _bench_realloc(bencher, vec![(); 1024]); }
+#[bench] fn u64_realloc(bencher: &mut Bencher) { _bench_realloc(bencher, vec![0u64; 1024]); }
+#[bench] fn u32x2_realloc(bencher: &mut Bencher) { _bench_realloc(bencher, vec![(0u32,0u32); 1024]); }
+#[bench] fn u8_u64_realloc(bencher: &mut Bencher) { _bench_realloc(bencher, vec![(0u8, 0u64); 512]); }
+#[bench] fn string10_realloc(bencher: &mut Bencher) { _bench_realloc(bencher, vec![format!("grawwwwrr!"); 1024]); }
+#[bench] fn string20_realloc(bencher: &mut Bencher) { _bench_realloc(bencher, vec![format!("grawwwwrr!!!!!!!!!!!"); 512]); }
+#[bench] fn vec_u_s_realloc(bencher: &mut Bencher) { _bench_realloc(bencher, vec![vec![(0u64, format!("grawwwwrr!")); 32]; 32]); }
+#[bench] fn vec_u_vn_s_realloc(bencher: &mut Bencher) { _bench_realloc(bencher, vec![vec![(0u64, vec![(); 1 << 40], format!("grawwwwrr!")); 32]; 32]); }
+
+#[bench] fn empty_prealloc(bencher: &mut Bencher) { _bench_prealloc(bencher, vec![(); 1024]); }
+#[bench] fn u64_prealloc(bencher: &mut Bencher) { _bench_prealloc(bencher, vec![0u64; 1024]); }
+#[bench] fn u32x2_prealloc(bencher: &mut Bencher) { _bench_prealloc(bencher, vec![(0u32,0u32); 1024]); }
+#[bench] fn u8_u64_prealloc(bencher: &mut Bencher) { _bench_prealloc(bencher, vec![(0u8, 0u64); 512]); }
+#[bench] fn string10_prealloc(bencher: &mut Bencher) { _bench_prealloc(bencher, vec![format!("grawwwwrr!"); 1024]); }
+#[bench] fn string20_prealloc(bencher: &mut Bencher) { _bench_prealloc(bencher, vec![format!("grawwwwrr!!!!!!!!!!!"); 512]); }
+#[bench] fn vec_u_s_prealloc(bencher: &mut Bencher) { _bench_prealloc(bencher, vec![vec![(0u64, format!("grawwwwrr!")); 32]; 32]); }
+#[bench] fn vec_u_vn_s_prealloc(bencher: &mut Bencher) { _bench_prealloc(bencher, vec![vec![(0u64, vec![(); 1 << 40], format!("grawwwwrr!")); 32]; 32]); }
 
 fn _bench_copy<T: Columnation+Eq>(bencher: &mut Bencher, record: T) {
 
@@ -46,6 +63,29 @@ fn _bench_clone<T: Columnation+Eq+Clone>(bencher: &mut Bencher, record: T) {
         arena.clear();
         for _ in 0 .. 1024 {
             arena.push(record.clone());
+        }
+    });
+}
+
+fn _bench_realloc<T: Columnation+Eq>(bencher: &mut Bencher, record: T) {
+
+    bencher.iter(|| {
+        // prepare encoded data for bencher.bytes
+        let mut arena = ColumnStack::<T>::default();
+        for _ in 0 .. 1024 {
+            arena.copy(&record);
+        }
+    });
+}
+
+fn _bench_prealloc<T: Columnation+Eq>(bencher: &mut Bencher, record: T) {
+
+    bencher.iter(|| {
+        // prepare encoded data for bencher.bytes
+        let mut arena = ColumnStack::<T>::default();
+        arena.with_capacity_for(std::iter::repeat(&record).take(1024));
+        for _ in 0 .. 1024 {
+            arena.copy(&record);
         }
     });
 }


### PR DESCRIPTION
This PR adds a method `with_capacity_for` that takes an iterator of item references, and ensures that the associated regions are sized to absorb the items without further allocation. This contrasts with simply inserting all the items, which generally requires a sequence of allocations (though, probably no copies as `StableRegion` avoids them to avoid moving memory references).

There is a minor performance improvement, that could be more noticeable if I figure out how to get it working for tuples as well (the macro approach defeated me; we could use a non-macro implementation, or try and learn me how to do macros better). Below, the `_realloc` methods allocate a new `arena` for each 1024 elements, and the `_prealloc` methods preallocate that same arena.

```
running 32 tests
test empty_clone         ... bench:         995 ns/iter (+/- 342)
test empty_copy          ... bench:       2,580 ns/iter (+/- 903)
test empty_prealloc      ... bench:       2,690 ns/iter (+/- 340)
test empty_realloc       ... bench:       3,399 ns/iter (+/- 456)
test string10_clone      ... bench: 109,425,584 ns/iter (+/- 17,341,669)
test string10_copy       ... bench:   3,958,523 ns/iter (+/- 841,402)
test string10_prealloc   ... bench:   5,803,453 ns/iter (+/- 1,134,973)
test string10_realloc    ... bench:   7,654,376 ns/iter (+/- 1,315,336)
test string20_clone      ... bench:  58,495,756 ns/iter (+/- 5,841,260)
test string20_copy       ... bench:   2,143,482 ns/iter (+/- 283,319)
test string20_prealloc   ... bench:   3,697,056 ns/iter (+/- 1,290,679)
test string20_realloc    ... bench:   4,890,442 ns/iter (+/- 999,397)
test u32x2_clone         ... bench:   1,949,999 ns/iter (+/- 403,050)
test u32x2_copy          ... bench:     281,941 ns/iter (+/- 62,856)
test u32x2_prealloc      ... bench:   1,864,373 ns/iter (+/- 834,052)
test u32x2_realloc       ... bench:   2,012,450 ns/iter (+/- 1,070,816)
test u64_clone           ... bench:   1,914,774 ns/iter (+/- 317,104)
test u64_copy            ... bench:     245,819 ns/iter (+/- 58,103)
test u64_prealloc        ... bench:   1,960,735 ns/iter (+/- 668,307)
test u64_realloc         ... bench:   1,819,154 ns/iter (+/- 682,888)
test u8_u64_clone        ... bench:   1,862,818 ns/iter (+/- 281,470)
test u8_u64_copy         ... bench:     281,465 ns/iter (+/- 147,593)
test u8_u64_prealloc     ... bench:   1,924,098 ns/iter (+/- 1,401,616)
test u8_u64_realloc      ... bench:   1,659,763 ns/iter (+/- 811,065)
test vec_u_s_clone       ... bench: 121,367,440 ns/iter (+/- 11,643,038)
test vec_u_s_copy        ... bench:   4,709,149 ns/iter (+/- 364,672)
test vec_u_s_prealloc    ... bench:   9,831,307 ns/iter (+/- 1,640,445)
test vec_u_s_realloc     ... bench:  10,477,709 ns/iter (+/- 3,050,836)
test vec_u_vn_s_clone    ... bench: 136,503,571 ns/iter (+/- 12,999,160)
test vec_u_vn_s_copy     ... bench:   7,596,065 ns/iter (+/- 1,050,548)
test vec_u_vn_s_prealloc ... bench:  16,866,467 ns/iter (+/- 3,469,459)
test vec_u_vn_s_realloc  ... bench:  17,216,813 ns/iter (+/- 2,337,498)
```

cc @antiguru 