### PR TITLE
Estimate the size of a region's reachable allocations

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -83,7 +83,7 @@ fn _bench_prealloc<T: Columnation+Eq>(bencher: &mut Bencher, record: T) {
     bencher.iter(|| {
         // prepare encoded data for bencher.bytes
         let mut arena = ColumnStack::<T>::default();
-        arena.with_capacity_for(std::iter::repeat(&record).take(1024));
+        arena.reserve_items(std::iter::repeat(&record).take(1024));
         for _ in 0 .. 1024 {
             arena.copy(&record);
         }


### PR DESCRIPTION
Add a `Region::size_of` and `ColumnStack::size_of` function estimating the in-memory size of the structures. It should be correct with the current region implementations. Its performance is constant for fixed-size regions and roughly logarithmic for variably-sized regions, such as `StableRegion`, with a large basis.

This is inspired by https://github.com/MaterializeInc/database-issues/issues/535.