### PR TITLE
Allocate regions from mmap'ed files instead of the memory allocator.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,13 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-paste = "1.0.6"
-memmap2 = "0.5.8"
-tempfile = "3.3.0"
-libc = "0.2.137"
+paste = "1.0.14"
+memmap2 = "0.9"
+tempfile = "3.8.0"
+libc = "0.2.149"
+crossbeam-channel = "0.5.8"
 
 [profile.bench]
 debug = 1
+codegen-units = 1
+lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ paste = "1.0.14"
 memmap2 = "0.9"
 tempfile = "3.8.0"
 libc = "0.2.149"
-crossbeam-channel = "0.5.8"
+crossbeam-deque = "0.8.3"
 
 [profile.bench]
 debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,9 @@ edition = "2018"
 
 [dependencies]
 paste = "1.0.6"
+memmap2 = "0.5.8"
+tempfile = "3.3.0"
+libc = "0.2.137"
+
+[profile.bench]
+debug = 1


### PR DESCRIPTION
Allocate regions of memory for `VecRegion` using `mmap`. This should only serve as an example on how it could be done, but should not be considered stable in any way!

DO NOT MERGE