### PR TITLE
Only indicate allocated data in heap_size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,14 +235,18 @@ impl<T> StableRegion<T> {
     pub fn heap_size(&self, mut callback: impl FnMut(usize, usize)) {
         // Calculate heap size for local, stash, and stash entries
         let size_of_t = std::mem::size_of::<T>();
-        callback(
-            self.local.len() * size_of_t,
-            self.local.capacity() * size_of_t,
-        );
-        callback(
-            self.stash.len() * std::mem::size_of::<Vec<T>>(),
-            self.stash.capacity() * std::mem::size_of::<Vec<T>>(),
-        );
+        if self.local.capacity() > 0 {
+            callback(
+                self.local.len() * size_of_t,
+                self.local.capacity() * size_of_t,
+            );
+        }
+        if self.stash.capacity() > 0 {
+            callback(
+                self.stash.len() * std::mem::size_of::<Vec<T>>(),
+                self.stash.capacity() * std::mem::size_of::<Vec<T>>(),
+            );
+        }
         for stash in &self.stash {
             callback(stash.len() * size_of_t, stash.capacity() * size_of_t);
         }
@@ -366,7 +370,9 @@ mod columnstack {
         #[inline]
         pub fn heap_size(&self, mut callback: impl FnMut(usize, usize)) {
             let size_of = std::mem::size_of::<T>();
-            callback(self.local.len() * size_of, self.local.capacity() * size_of);
+            if self.local.capacity() > 0 {
+                callback(self.local.len() * size_of, self.local.capacity() * size_of);
+            }
             self.inner.heap_size(callback);
         }
 


### PR DESCRIPTION
Prior to this change, calling heap_size on a region would reveal information about allocations that were not filled, i.e., did not own a valid heap allocation. This was not a problem as long as the caller did not count the number of callback invocations, but would invoke the callback more times than there are owned allocations.

After this change, we only call the callback if the allocation exists, for example if a vector has a capacity. This is aligned with the specification.