### PR TITLE
Provide a `CopyInto` trait to copy destructured elements into regions

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,3 +18,18 @@ fn _test_pass<T: Columnation+Eq>(record: T) {
         assert!(element == &record);
     }
 }
+
+#[test]
+fn copy_into() {
+    let o = Some("test");
+    let mut ts: ColumnStack<Option<String>> = ColumnStack::default();
+    ts.copy_onto(&o);
+
+    let o = ("abc", "def");
+    let mut ts: ColumnStack<(String, String)> = ColumnStack::default();
+    ts.copy_onto(&o);
+
+    let o: Result<_, ()> = Ok("asdf");
+    let mut ts: ColumnStack<Result<String, ()>> = ColumnStack::default();
+    ts.copy_onto(&o);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -25,11 +25,31 @@ fn copy_into() {
     let mut ts: ColumnStack<Option<String>> = ColumnStack::default();
     ts.copy_onto(&o);
 
+    let o = Some(1);
+    let mut ts: ColumnStack<Option<usize>> = ColumnStack::default();
+    ts.copy_onto(&o);
+
     let o = ("abc", "def");
     let mut ts: ColumnStack<(String, String)> = ColumnStack::default();
     ts.copy_onto(&o);
 
+    let o = ("abc", &o);
+    let mut ts: ColumnStack<(String, (String, String))> = ColumnStack::default();
+    ts.copy_onto(&o);
+
     let o: Result<_, ()> = Ok("asdf");
     let mut ts: ColumnStack<Result<String, ()>> = ColumnStack::default();
+    ts.copy_onto(&o);
+
+    let o = vec![("asdf", "def".to_string())];
+    let mut ts: ColumnStack<Vec<(String, String)>> = ColumnStack::default();
+    ts.copy_onto(&o);
+
+    let binding = ("asdf", Some("def".to_string()));
+    let o = vec![&binding];
+    let mut ts: ColumnStack<Vec<(String, Option<String>)>> = ColumnStack::default();
+    ts.copy_onto(&o);
+    let o = [&binding];
+    let mut ts: ColumnStack<Vec<(String, Option<String>)>> = ColumnStack::default();
     ts.copy_onto(&o);
 }


### PR DESCRIPTION
Currently, regions can only copy references to their owned type. For example, a `String` region can only accept `&String`, but not `&str`. Similarly, a tuple region can only accept `&(A, B)`, but not references within the tuple, say `&(&A, &B)`. This would be desirable when the caller doesn't have an owned variant of the right type available.

This change introduces a `CopyInto` trait that allows various types to explain how they can be copied into specific regions. To continue the above example, we implement `CopyInto<StringStack>` for `String`, `str`, and a few other types that all can be dereferenced into byte slices, suitable for reconstructing an owned `String`. The implementation for `Option`, `Region`, `Vec`, and tuples recursively `copy_into`, which allows to construct arbitrarily complex nested structures.

As an example, this allows one to write:
```rust
    let binding = ("asdf", Some("def".to_string()));
    let o = vec![&binding];
    let mut ts: ColumnStack<Vec<(String, Option<String>)>> = ColumnStack::default();
    ts.copy_onto(&o);
```

One disadvantage of this change is that providing blanket implementations is difficult because they conflict, and preclude specialized implementations. For example, instead of providing a blanket implementation for `Iterator` to construct `Vec`, we provide several specific implementations for `Vec`, `[T]`, `[T; N]`.