### PR TITLE
use the original smallvec capacity after copying into region

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -720,7 +720,7 @@ mod implementations {
                 let inner = &mut self.inner;
                 if item.spilled() {
                     let slice = self.region.copy_iter(item.iter().map(|element| inner.copy(element)));
-                    SmallVec::from_raw_parts(slice.as_mut_ptr(), item.len(), item.len())
+                    SmallVec::from_raw_parts(slice.as_mut_ptr(), item.len(), item.capacity())
                 }
                 else { item.clone() }
             }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -6,6 +6,14 @@ use columnation::*;
 #[test] fn test_u64_pass() { _test_pass(vec![0u64; 1024]); }
 #[test] fn test_string_pass() { _test_pass(vec![format!("grawwwwrr!"); 1024]); }
 #[test] fn test_vec_u_s_pass() { _test_pass(vec![vec![(0u64, format!("grawwwwrr!")); 32]; 32]); }
+#[test]
+fn test_smallvec() {
+    use smallvec::SmallVec;
+    let mut v: SmallVec<[i32; 1]> = SmallVec::with_capacity(2);
+    assert!(v.spilled());
+    v.push(42);
+    _test_pass(v);
+}
 
 fn _test_pass<T: Columnation+Eq>(record: T) {
 


### PR DESCRIPTION
`SmallVec` uses the allocated capacity to decide whether or not its data
is spilled so we must preserve it if we're taking the spilled path.