### PR TITLE
smallvec: unconditionally copy the items into the region

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -727,6 +727,7 @@ mod implementations {
                     for element in elements {
                         item_new.push(element);
                     }
+                    assert!(!item_new.spilled());
                     item_new
                 } else {
                     let slice = self.region.copy_iter(elements);


### PR DESCRIPTION
Previously inlined elements would be cloned instead of being copied into
the region which goes against the intent of copying an item into a
region.

Here this is fixed by checking whether the number of elements in the
vector can be inlined and if so we create a new `SmallVec` that contains
copied elements.